### PR TITLE
Configure Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>valomedia/renovate-config"]
+}


### PR DESCRIPTION
closes valomedia/Pandatrack#6

Added root-level renovate.json extending the shared github>valomedia/renovate-config preset. Confirmed the repository has Renovate-supported CocoaPods inputs (Podfile, Podfile.lock, Podspecs/ObservedOptionalObject.podspec) and an active GitHub Actions CI workflow. Checked open PRs for existing Renovate/dependency update activity and found none yet, which is expected before this config is merged onto the default branch. Committed the change as 36d9957 (chore: configure renovate). Verification: python3 -m json.tool renovate.json, jq validation of schema and extends, git diff --check, repository manifest/workflow inspection, and gh pr list for open dependency/Renovate PRs.