### PR TITLE
Add dedicated CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,35 @@ permissions:
   contents: read
 
 jobs:
+  build:
+    name: Build
+    runs-on: macos-15
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Install CocoaPods dependencies
+        run: pod install --repo-update
+
+      - name: Create iOS simulator
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/create-ios-simulator.py "Pandatrack CI iPhone"
+
+      - name: Build app
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -workspace Chronos.xcworkspace \
+            -scheme Pandatrack \
+            -destination "platform=iOS Simulator,id=${PANDATRACK_SIMULATOR_UDID}" \
+            CODE_SIGNING_ALLOWED=NO
+
   unit-tests:
     name: Unit Tests
     runs-on: macos-15


### PR DESCRIPTION
closes valomedia/Pandatrack#17

Added a dedicated Build job to .github/workflows/ci.yml. The new job preserves the existing CI triggers, read-only permissions, fork-PR skip policy, and setup pattern used by the existing jobs: checkout, Xcode selection, CocoaPods install, simulator creation, then xcodebuild. Unit-test and instrumented-test jobs remain separate and continue running their existing xcodebuild test commands. Verification: parsed and asserted the workflow shape with a Python/PyYAML check, ran git diff --check, compiled the simulator helper script with python3 -m py_compile, and confirmed the branch is clean after committing with `ci: add dedicated build job`. xcodebuild execution was unavailable on this non-macOS host.