### PR TITLE
Add screenshot artifacts for instrumented tests

### DIFF
--- a/.github/scripts/rename-xcresult-attachments.py
+++ b/.github/scripts/rename-xcresult-attachments.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Rename exported xcresult screenshots using their attachment names."""
+"""Rename exported xcresult screenshots using their attachment slugs."""
 
 from __future__ import annotations
 
@@ -21,6 +21,37 @@ def attachment_slug(suggested_name: str) -> str:
     return slug
 
 
+def png_pixel_size(path: Path) -> tuple[int, int]:
+    data = path.read_bytes()
+    if len(data) < 24 or data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise SystemExit(f"Screenshot is not a valid PNG: {path}")
+
+    return int.from_bytes(data[16:20], "big"), int.from_bytes(data[20:24], "big")
+
+
+def verify_orientation(path: Path) -> None:
+    stem = path.stem
+    if stem.endswith("-landscape") or re.search(r"-landscape-[0-9]+$", stem):
+        width, height = png_pixel_size(path)
+        if width <= height:
+            raise SystemExit(f"Landscape screenshot is not wider than high: {path.name} ({width}x{height})")
+    elif stem.endswith("-portrait") or re.search(r"-portrait-[0-9]+$", stem):
+        width, height = png_pixel_size(path)
+        if height <= width:
+            raise SystemExit(f"Portrait screenshot is not higher than wide: {path.name} ({width}x{height})")
+
+
+def unique_destination(output_directory: Path, slug: str, used_destinations: set[Path]) -> Path:
+    destination = output_directory / f"{slug}.png"
+    index = 2
+    while destination.exists() or destination in used_destinations:
+        destination = output_directory / f"{slug}-{index}.png"
+        index += 1
+
+    used_destinations.add(destination)
+    return destination
+
+
 def main() -> None:
     if len(sys.argv) != 2:
         raise SystemExit("Usage: rename-xcresult-attachments.py <exported-attachments-directory>")
@@ -31,17 +62,17 @@ def main() -> None:
         raise SystemExit(f"Export log does not exist: {export_log_path}")
 
     exported_screenshots = set(output_directory.rglob("*.png"))
+    used_destinations: set[Path] = set()
     renamed_count = 0
     for match in EXPORT_LOG_PATTERN.finditer(export_log_path.read_text(encoding="utf-8")):
         source = output_directory / Path(match.group("file")).name
         if not source.exists():
             raise SystemExit(f"Exported screenshot does not exist: {source}")
 
-        destination = output_directory / f"{attachment_slug(match.group('suggested'))}.png"
-        if destination.exists():
-            raise SystemExit(f"Duplicate screenshot attachment name: {destination.name}")
-
+        slug = attachment_slug(match.group("suggested"))
+        destination = unique_destination(output_directory, slug, used_destinations)
         source.replace(destination)
+        verify_orientation(destination)
         renamed_count += 1
 
     if renamed_count != len(exported_screenshots):

--- a/.github/scripts/rename-xcresult-attachments.py
+++ b/.github/scripts/rename-xcresult-attachments.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Rename exported xcresult PNG attachments using their XCTest attachment names."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections import deque
+from pathlib import Path
+from typing import Any, Iterable
+
+UUID_PNG_PATTERN = re.compile(
+    r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\.png$"
+)
+
+
+def xc_value(value: Any) -> str | None:
+    if isinstance(value, dict):
+        wrapped_value = value.get("_value")
+        if wrapped_value is not None:
+            return str(wrapped_value)
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def run_xcresulttool_get(xcresult_path: Path, object_id: str | None = None) -> dict[str, Any] | None:
+    command = ["xcrun", "xcresulttool", "get", "--format", "json", "--path", str(xcresult_path)]
+    if object_id:
+        command.extend(["--id", object_id])
+
+    for candidate in (command, command[:3] + ["--legacy"] + command[3:]):
+        try:
+            result = subprocess.run(candidate, check=True, capture_output=True, text=True)
+            return json.loads(result.stdout)
+        except subprocess.CalledProcessError as error:
+            last_error = error
+        except json.JSONDecodeError:
+            return None
+
+    print(f"warning: could not read xcresult object {object_id or '<root>'}: {last_error}", file=sys.stderr)
+    return None
+
+
+def iter_child_nodes(node: Any) -> Iterable[Any]:
+    if isinstance(node, dict):
+        yield from node.values()
+    elif isinstance(node, list):
+        yield from node
+
+
+def find_json_refs(node: Any, parent_key: str = "") -> Iterable[str]:
+    if isinstance(node, dict):
+        if parent_key.endswith("Ref") and parent_key != "payloadRef":
+            ref_id = xc_value(node.get("id"))
+            if ref_id:
+                yield ref_id
+
+        for key, value in node.items():
+            yield from find_json_refs(value, key)
+    elif isinstance(node, list):
+        for value in node:
+            yield from find_json_refs(value, parent_key)
+
+
+def find_png_attachments(node: Any) -> Iterable[tuple[str, str]]:
+    if isinstance(node, dict):
+        payload_ref = node.get("payloadRef")
+        filename = xc_value(node.get("filename"))
+        name = xc_value(node.get("name")) or filename
+        uniform_type = xc_value(node.get("uniformTypeIdentifier"))
+
+        if isinstance(payload_ref, dict) and filename and name:
+            is_png = filename.lower().endswith(".png") or uniform_type == "public.png"
+            if is_png:
+                yield filename, name
+
+        for value in node.values():
+            yield from find_png_attachments(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from find_png_attachments(value)
+
+
+def slugify(value: str) -> str:
+    slug_parts: list[str] = []
+    last_character_was_dash = False
+
+    for character in value.lower():
+        if character.isalnum():
+            slug_parts.append(character)
+            last_character_was_dash = False
+        elif not last_character_was_dash:
+            slug_parts.append("-")
+            last_character_was_dash = True
+
+    return "".join(slug_parts).strip("-") or "screenshot"
+
+
+def unique_path(output_directory: Path, slug: str, source: Path, used_paths: set[Path]) -> Path:
+    candidate = output_directory / f"{slug}.png"
+    index = 2
+    while candidate in used_paths or (candidate.exists() and candidate != source):
+        candidate = output_directory / f"{slug}-{index}.png"
+        index += 1
+    used_paths.add(candidate)
+    return candidate
+
+
+def discover_attachment_names(xcresult_path: Path) -> list[tuple[str, str]]:
+    root = run_xcresulttool_get(xcresult_path)
+    if root is None:
+        raise SystemExit("Could not read xcresult root object.")
+
+    attachments: list[tuple[str, str]] = []
+    seen_attachment_filenames: set[str] = set()
+    seen_refs: set[str] = set()
+    refs = deque(find_json_refs(root))
+
+    for filename, name in find_png_attachments(root):
+        if filename not in seen_attachment_filenames:
+            attachments.append((filename, name))
+            seen_attachment_filenames.add(filename)
+
+    while refs:
+        ref_id = refs.popleft()
+        if ref_id in seen_refs:
+            continue
+        seen_refs.add(ref_id)
+
+        node = run_xcresulttool_get(xcresult_path, ref_id)
+        if node is None:
+            continue
+
+        for filename, name in find_png_attachments(node):
+            if filename not in seen_attachment_filenames:
+                attachments.append((filename, name))
+                seen_attachment_filenames.add(filename)
+
+        refs.extend(ref for ref in find_json_refs(node) if ref not in seen_refs)
+
+    return attachments
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: rename-xcresult-attachments.py <result.xcresult> <exported-attachments-directory>")
+
+    xcresult_path = Path(sys.argv[1])
+    output_directory = Path(sys.argv[2])
+
+    if not xcresult_path.exists():
+        raise SystemExit(f"Result bundle does not exist: {xcresult_path}")
+    if not output_directory.exists():
+        raise SystemExit(f"Attachment directory does not exist: {output_directory}")
+
+    attachments = discover_attachment_names(xcresult_path)
+    if not attachments:
+        raise SystemExit("No PNG attachment metadata found in result bundle.")
+
+    exported_files = {path.name: path for path in output_directory.rglob("*.png")}
+    used_paths: set[Path] = set()
+    renamed_count = 0
+
+    for filename, name in attachments:
+        source = exported_files.get(filename)
+        if source is None:
+            raise SystemExit(f"Exported PNG attachment missing for result filename: {filename}")
+
+        slug = slugify(Path(name).stem)
+        destination = unique_path(output_directory, slug, source, used_paths)
+        if source != destination:
+            source.replace(destination)
+        renamed_count += 1
+
+    uuid_filenames = sorted(path.name for path in output_directory.rglob("*.png") if UUID_PNG_PATTERN.match(path.name))
+    if uuid_filenames:
+        raise SystemExit(f"Exported screenshots still have UUID filenames: {', '.join(uuid_filenames)}")
+
+    print(f"Renamed {renamed_count} screenshot attachment(s) with readable filenames.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/rename-xcresult-attachments.py
+++ b/.github/scripts/rename-xcresult-attachments.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""Rename exported xcresult PNG attachments using xcresulttool's suggested names."""
+"""Rename exported xcresult PNG screenshots using xcresulttool's suggested names."""
 
 from __future__ import annotations
 
-import json
+import hashlib
 import re
 import sys
 from pathlib import Path
-from typing import Any, Iterable
 
 UUID_PNG_PATTERN = re.compile(
     r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\.png$"
@@ -16,27 +15,6 @@ SUGGESTED_SUFFIX_PATTERN = re.compile(
     r"_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
 )
 EXPORT_LOG_PATTERN = re.compile(r"File:\s*(?P<file>[^,\s]+\.png),\s*suggested name:\s*\"(?P<suggested>[^\"]+\.png)\"")
-
-
-def iter_dicts(node: Any) -> Iterable[dict[str, Any]]:
-    if isinstance(node, dict):
-        yield node
-        for value in node.values():
-            yield from iter_dicts(value)
-    elif isinstance(node, list):
-        for value in node:
-            yield from iter_dicts(value)
-
-
-def iter_strings(node: Any) -> Iterable[str]:
-    if isinstance(node, str):
-        yield node
-    elif isinstance(node, dict):
-        for value in node.values():
-            yield from iter_strings(value)
-    elif isinstance(node, list):
-        for value in node:
-            yield from iter_strings(value)
 
 
 def slugify(value: str) -> str:
@@ -60,91 +38,71 @@ def slug_from_suggested_name(suggested_name: str) -> str:
     return slugify(stem)
 
 
-def unique_path(output_directory: Path, slug: str, source: Path, used_paths: set[Path]) -> Path:
-    candidate = output_directory / f"{slug}.png"
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def unique_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+
     index = 2
-    while candidate in used_paths or (candidate.exists() and candidate != source):
-        candidate = output_directory / f"{slug}-{index}.png"
+    while True:
+        candidate = path.with_name(f"{path.stem}-{index}{path.suffix}")
+        if not candidate.exists():
+            return candidate
         index += 1
-    used_paths.add(candidate)
-    return candidate
 
 
-def discover_mappings_from_manifest(output_directory: Path, exported_names: set[str]) -> dict[str, str]:
-    manifest_path = output_directory / "manifest.json"
-    if not manifest_path.exists():
-        return {}
+def rename_exported_screenshot(source: Path, destination: Path) -> str:
+    if destination.exists():
+        if sha256(source) == sha256(destination):
+            source.unlink()
+            return "skipped duplicate"
+        destination = unique_path(destination)
 
-    with manifest_path.open(encoding="utf-8") as manifest_file:
-        manifest = json.load(manifest_file)
-
-    mappings: dict[str, str] = {}
-    for item in iter_dicts(manifest):
-        strings = [Path(value).name for value in iter_strings(item) if value.lower().endswith(".png")]
-        source_names = sorted({value for value in strings if value in exported_names})
-        suggested_names = sorted(
-            value
-            for value in strings
-            if value not in exported_names and not UUID_PNG_PATTERN.match(value)
-        )
-        if len(source_names) == 1 and suggested_names:
-            mappings[source_names[0]] = suggested_names[0]
-
-    return mappings
-
-
-def discover_mappings_from_export_log(output_directory: Path, exported_names: set[str]) -> dict[str, str]:
-    export_log_path = output_directory / "export.log"
-    if not export_log_path.exists():
-        return {}
-
-    mappings: dict[str, str] = {}
-    for match in EXPORT_LOG_PATTERN.finditer(export_log_path.read_text(encoding="utf-8")):
-        source_name = Path(match.group("file")).name
-        suggested_name = Path(match.group("suggested")).name
-        if source_name in exported_names:
-            mappings[source_name] = suggested_name
-
-    return mappings
+    source.replace(destination)
+    return "renamed"
 
 
 def main() -> None:
-    if len(sys.argv) != 3:
-        raise SystemExit("Usage: rename-xcresult-attachments.py <result.xcresult> <exported-attachments-directory>")
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: rename-xcresult-attachments.py <exported-attachments-directory>")
 
-    output_directory = Path(sys.argv[2])
-    if not output_directory.exists():
-        raise SystemExit(f"Attachment directory does not exist: {output_directory}")
+    output_directory = Path(sys.argv[1])
+    export_log_path = output_directory / "export.log"
+    if not export_log_path.exists():
+        raise SystemExit(f"Export log does not exist: {export_log_path}")
 
-    exported_files = {path.name: path for path in output_directory.rglob("*.png")}
-    if not exported_files:
-        raise SystemExit("No exported PNG screenshots found.")
-
-    mappings = discover_mappings_from_manifest(output_directory, set(exported_files))
-    if not mappings:
-        mappings = discover_mappings_from_export_log(output_directory, set(exported_files))
-    if not mappings:
-        raise SystemExit("Could not find suggested screenshot names in xcresulttool export metadata.")
-
-    missing_names = sorted(set(exported_files) - set(mappings))
-    if missing_names:
-        raise SystemExit(f"No suggested names found for exported screenshots: {', '.join(missing_names)}")
-
-    used_paths: set[Path] = set()
     renamed_count = 0
-    for source_name, suggested_name in sorted(mappings.items()):
-        source = exported_files[source_name]
-        slug = slug_from_suggested_name(suggested_name)
-        destination = unique_path(output_directory, slug, source, used_paths)
-        if source != destination:
-            source.replace(destination)
-        renamed_count += 1
+    duplicate_count = 0
+    for match in EXPORT_LOG_PATTERN.finditer(export_log_path.read_text(encoding="utf-8")):
+        source = output_directory / Path(match.group("file")).name
+        if not source.exists():
+            raise SystemExit(f"Exported screenshot does not exist: {source}")
+
+        slug = slug_from_suggested_name(match.group("suggested"))
+        result = rename_exported_screenshot(source, output_directory / f"{slug}.png")
+        if result == "renamed":
+            renamed_count += 1
+        else:
+            duplicate_count += 1
+
+    if renamed_count == 0:
+        raise SystemExit("No exported PNG screenshots were renamed.")
 
     uuid_filenames = sorted(path.name for path in output_directory.rglob("*.png") if UUID_PNG_PATTERN.match(path.name))
     if uuid_filenames:
         raise SystemExit(f"Exported screenshots still have UUID filenames: {', '.join(uuid_filenames)}")
 
-    print(f"Renamed {renamed_count} screenshot attachment(s) with readable filenames.")
+    message = f"Renamed {renamed_count} screenshot attachment(s) with readable filenames."
+    if duplicate_count:
+        message += f" Skipped {duplicate_count} duplicate screenshot attachment(s)."
+    print(message)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/rename-xcresult-attachments.py
+++ b/.github/scripts/rename-xcresult-attachments.py
@@ -1,72 +1,24 @@
 #!/usr/bin/env python3
-"""Rename exported xcresult PNG screenshots using xcresulttool's suggested names."""
+"""Rename exported xcresult screenshots using their attachment names."""
 
 from __future__ import annotations
 
-import hashlib
 import re
 import sys
 from pathlib import Path
 
-UUID_PNG_PATTERN = re.compile(
-    r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\.png$"
-)
-SUGGESTED_SUFFIX_PATTERN = re.compile(
+GENERATED_SUFFIX_PATTERN = re.compile(
     r"_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
 )
-EXPORT_LOG_PATTERN = re.compile(r"File:\s*(?P<file>[^,\s]+\.png),\s*suggested name:\s*\"(?P<suggested>[^\"]+\.png)\"")
+EXPORT_LOG_PATTERN = re.compile(r'File:\s*(?P<file>[^,\s]+\.png),\s*suggested name:\s*"(?P<suggested>[^\"]+\.png)"')
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
-def slugify(value: str) -> str:
-    slug_parts: list[str] = []
-    last_character_was_dash = False
-
-    for character in value.lower():
-        if character.isalnum():
-            slug_parts.append(character)
-            last_character_was_dash = False
-        elif not last_character_was_dash:
-            slug_parts.append("-")
-            last_character_was_dash = True
-
-    return "".join(slug_parts).strip("-") or "screenshot"
-
-
-def slug_from_suggested_name(suggested_name: str) -> str:
-    stem = Path(suggested_name).stem
-    stem = SUGGESTED_SUFFIX_PATTERN.sub("", stem)
-    return slugify(stem)
-
-
-def sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as file:
-        for chunk in iter(lambda: file.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def unique_path(path: Path) -> Path:
-    if not path.exists():
-        return path
-
-    index = 2
-    while True:
-        candidate = path.with_name(f"{path.stem}-{index}{path.suffix}")
-        if not candidate.exists():
-            return candidate
-        index += 1
-
-
-def rename_exported_screenshot(source: Path, destination: Path) -> str:
-    if destination.exists():
-        if sha256(source) == sha256(destination):
-            source.unlink()
-            return "skipped duplicate"
-        destination = unique_path(destination)
-
-    source.replace(destination)
-    return "renamed"
+def attachment_slug(suggested_name: str) -> str:
+    slug = GENERATED_SUFFIX_PATTERN.sub("", Path(suggested_name).stem)
+    if not SLUG_PATTERN.fullmatch(slug):
+        raise SystemExit(f"Screenshot attachment name is not a slug: {slug}")
+    return slug
 
 
 def main() -> None:
@@ -78,31 +30,26 @@ def main() -> None:
     if not export_log_path.exists():
         raise SystemExit(f"Export log does not exist: {export_log_path}")
 
+    exported_screenshots = set(output_directory.rglob("*.png"))
     renamed_count = 0
-    duplicate_count = 0
     for match in EXPORT_LOG_PATTERN.finditer(export_log_path.read_text(encoding="utf-8")):
         source = output_directory / Path(match.group("file")).name
         if not source.exists():
             raise SystemExit(f"Exported screenshot does not exist: {source}")
 
-        slug = slug_from_suggested_name(match.group("suggested"))
-        result = rename_exported_screenshot(source, output_directory / f"{slug}.png")
-        if result == "renamed":
-            renamed_count += 1
-        else:
-            duplicate_count += 1
+        destination = output_directory / f"{attachment_slug(match.group('suggested'))}.png"
+        if destination.exists():
+            raise SystemExit(f"Duplicate screenshot attachment name: {destination.name}")
 
-    if renamed_count == 0:
-        raise SystemExit("No exported PNG screenshots were renamed.")
+        source.replace(destination)
+        renamed_count += 1
 
-    uuid_filenames = sorted(path.name for path in output_directory.rglob("*.png") if UUID_PNG_PATTERN.match(path.name))
-    if uuid_filenames:
-        raise SystemExit(f"Exported screenshots still have UUID filenames: {', '.join(uuid_filenames)}")
+    if renamed_count != len(exported_screenshots):
+        raise SystemExit(
+            f"Renamed {renamed_count} of {len(exported_screenshots)} exported PNG screenshot attachment(s)."
+        )
 
-    message = f"Renamed {renamed_count} screenshot attachment(s) with readable filenames."
-    if duplicate_count:
-        message += f" Skipped {duplicate_count} duplicate screenshot attachment(s)."
-    print(message)
+    print(f"Renamed {renamed_count} screenshot attachment(s).")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/rename-xcresult-attachments.py
+++ b/.github/scripts/rename-xcresult-attachments.py
@@ -1,87 +1,42 @@
 #!/usr/bin/env python3
-"""Rename exported xcresult PNG attachments using their XCTest attachment names."""
+"""Rename exported xcresult PNG attachments using xcresulttool's suggested names."""
 
 from __future__ import annotations
 
 import json
 import re
-import subprocess
 import sys
-from collections import deque
 from pathlib import Path
 from typing import Any, Iterable
 
 UUID_PNG_PATTERN = re.compile(
     r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\.png$"
 )
+SUGGESTED_SUFFIX_PATTERN = re.compile(
+    r"_[0-9]+_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+)
+EXPORT_LOG_PATTERN = re.compile(r"File:\s*(?P<file>[^,\s]+\.png),\s*suggested name:\s*\"(?P<suggested>[^\"]+\.png)\"")
 
 
-def xc_value(value: Any) -> str | None:
-    if isinstance(value, dict):
-        wrapped_value = value.get("_value")
-        if wrapped_value is not None:
-            return str(wrapped_value)
-    if isinstance(value, str):
-        return value
-    return None
-
-
-def run_xcresulttool_get(xcresult_path: Path, object_id: str | None = None) -> dict[str, Any] | None:
-    command = ["xcrun", "xcresulttool", "get", "--format", "json", "--path", str(xcresult_path)]
-    if object_id:
-        command.extend(["--id", object_id])
-
-    for candidate in (command, command[:3] + ["--legacy"] + command[3:]):
-        try:
-            result = subprocess.run(candidate, check=True, capture_output=True, text=True)
-            return json.loads(result.stdout)
-        except subprocess.CalledProcessError as error:
-            last_error = error
-        except json.JSONDecodeError:
-            return None
-
-    print(f"warning: could not read xcresult object {object_id or '<root>'}: {last_error}", file=sys.stderr)
-    return None
-
-
-def iter_child_nodes(node: Any) -> Iterable[Any]:
+def iter_dicts(node: Any) -> Iterable[dict[str, Any]]:
     if isinstance(node, dict):
-        yield from node.values()
-    elif isinstance(node, list):
-        yield from node
-
-
-def find_json_refs(node: Any, parent_key: str = "") -> Iterable[str]:
-    if isinstance(node, dict):
-        if parent_key.endswith("Ref") and parent_key != "payloadRef":
-            ref_id = xc_value(node.get("id"))
-            if ref_id:
-                yield ref_id
-
-        for key, value in node.items():
-            yield from find_json_refs(value, key)
-    elif isinstance(node, list):
-        for value in node:
-            yield from find_json_refs(value, parent_key)
-
-
-def find_png_attachments(node: Any) -> Iterable[tuple[str, str]]:
-    if isinstance(node, dict):
-        payload_ref = node.get("payloadRef")
-        filename = xc_value(node.get("filename"))
-        name = xc_value(node.get("name")) or filename
-        uniform_type = xc_value(node.get("uniformTypeIdentifier"))
-
-        if isinstance(payload_ref, dict) and filename and name:
-            is_png = filename.lower().endswith(".png") or uniform_type == "public.png"
-            if is_png:
-                yield filename, name
-
+        yield node
         for value in node.values():
-            yield from find_png_attachments(value)
+            yield from iter_dicts(value)
     elif isinstance(node, list):
         for value in node:
-            yield from find_png_attachments(value)
+            yield from iter_dicts(value)
+
+
+def iter_strings(node: Any) -> Iterable[str]:
+    if isinstance(node, str):
+        yield node
+    elif isinstance(node, dict):
+        for value in node.values():
+            yield from iter_strings(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from iter_strings(value)
 
 
 def slugify(value: str) -> str:
@@ -99,6 +54,12 @@ def slugify(value: str) -> str:
     return "".join(slug_parts).strip("-") or "screenshot"
 
 
+def slug_from_suggested_name(suggested_name: str) -> str:
+    stem = Path(suggested_name).stem
+    stem = SUGGESTED_SUFFIX_PATTERN.sub("", stem)
+    return slugify(stem)
+
+
 def unique_path(output_directory: Path, slug: str, source: Path, used_paths: set[Path]) -> Path:
     candidate = output_directory / f"{slug}.png"
     index = 2
@@ -109,67 +70,71 @@ def unique_path(output_directory: Path, slug: str, source: Path, used_paths: set
     return candidate
 
 
-def discover_attachment_names(xcresult_path: Path) -> list[tuple[str, str]]:
-    root = run_xcresulttool_get(xcresult_path)
-    if root is None:
-        raise SystemExit("Could not read xcresult root object.")
+def discover_mappings_from_manifest(output_directory: Path, exported_names: set[str]) -> dict[str, str]:
+    manifest_path = output_directory / "manifest.json"
+    if not manifest_path.exists():
+        return {}
 
-    attachments: list[tuple[str, str]] = []
-    seen_attachment_filenames: set[str] = set()
-    seen_refs: set[str] = set()
-    refs = deque(find_json_refs(root))
+    with manifest_path.open(encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
 
-    for filename, name in find_png_attachments(root):
-        if filename not in seen_attachment_filenames:
-            attachments.append((filename, name))
-            seen_attachment_filenames.add(filename)
+    mappings: dict[str, str] = {}
+    for item in iter_dicts(manifest):
+        strings = [Path(value).name for value in iter_strings(item) if value.lower().endswith(".png")]
+        source_names = sorted({value for value in strings if value in exported_names})
+        suggested_names = sorted(
+            value
+            for value in strings
+            if value not in exported_names and not UUID_PNG_PATTERN.match(value)
+        )
+        if len(source_names) == 1 and suggested_names:
+            mappings[source_names[0]] = suggested_names[0]
 
-    while refs:
-        ref_id = refs.popleft()
-        if ref_id in seen_refs:
-            continue
-        seen_refs.add(ref_id)
+    return mappings
 
-        node = run_xcresulttool_get(xcresult_path, ref_id)
-        if node is None:
-            continue
 
-        for filename, name in find_png_attachments(node):
-            if filename not in seen_attachment_filenames:
-                attachments.append((filename, name))
-                seen_attachment_filenames.add(filename)
+def discover_mappings_from_export_log(output_directory: Path, exported_names: set[str]) -> dict[str, str]:
+    export_log_path = output_directory / "export.log"
+    if not export_log_path.exists():
+        return {}
 
-        refs.extend(ref for ref in find_json_refs(node) if ref not in seen_refs)
+    mappings: dict[str, str] = {}
+    for match in EXPORT_LOG_PATTERN.finditer(export_log_path.read_text(encoding="utf-8")):
+        source_name = Path(match.group("file")).name
+        suggested_name = Path(match.group("suggested")).name
+        if source_name in exported_names:
+            mappings[source_name] = suggested_name
 
-    return attachments
+    return mappings
 
 
 def main() -> None:
     if len(sys.argv) != 3:
         raise SystemExit("Usage: rename-xcresult-attachments.py <result.xcresult> <exported-attachments-directory>")
 
-    xcresult_path = Path(sys.argv[1])
     output_directory = Path(sys.argv[2])
-
-    if not xcresult_path.exists():
-        raise SystemExit(f"Result bundle does not exist: {xcresult_path}")
     if not output_directory.exists():
         raise SystemExit(f"Attachment directory does not exist: {output_directory}")
 
-    attachments = discover_attachment_names(xcresult_path)
-    if not attachments:
-        raise SystemExit("No PNG attachment metadata found in result bundle.")
-
     exported_files = {path.name: path for path in output_directory.rglob("*.png")}
+    if not exported_files:
+        raise SystemExit("No exported PNG screenshots found.")
+
+    mappings = discover_mappings_from_manifest(output_directory, set(exported_files))
+    if not mappings:
+        mappings = discover_mappings_from_export_log(output_directory, set(exported_files))
+    if not mappings:
+        raise SystemExit("Could not find suggested screenshot names in xcresulttool export metadata.")
+
+    missing_names = sorted(set(exported_files) - set(mappings))
+    if missing_names:
+        raise SystemExit(f"No suggested names found for exported screenshots: {', '.join(missing_names)}")
+
     used_paths: set[Path] = set()
     renamed_count = 0
-
-    for filename, name in attachments:
-        source = exported_files.get(filename)
-        if source is None:
-            raise SystemExit(f"Exported PNG attachment missing for result filename: {filename}")
-
-        slug = slugify(Path(name).stem)
+    for source_name, suggested_name in sorted(mappings.items()):
+        source = exported_files[source_name]
+        slug = slug_from_suggested_name(suggested_name)
         destination = unique_path(output_directory, slug, source, used_paths)
         if source != destination:
             source.replace(destination)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,6 @@ jobs:
             --output-path TestResults/Screenshots \
             | tee TestResults/Screenshots/export.log
           python3 .github/scripts/rename-xcresult-attachments.py \
-            TestResults/InstrumentedTests.xcresult \
             TestResults/Screenshots
 
           screenshot_count=$(find TestResults/Screenshots -type f -iname '*.png' | wc -l | tr -d ' ')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,33 @@ jobs:
             -only-testing:ChronosUITests \
             CODE_SIGNING_ALLOWED=NO
 
-      - name: Upload instrumented test results
+      - name: Export instrumented test screenshots
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -d TestResults/InstrumentedTests.xcresult ]; then
+            echo "No instrumented test result bundle found."
+            exit 1
+          fi
+
+          rm -rf TestResults/Screenshots
+          mkdir -p TestResults/Screenshots
+          xcrun xcresulttool export attachments \
+            --path TestResults/InstrumentedTests.xcresult \
+            --output-path TestResults/Screenshots
+
+          screenshot_count=$(find TestResults/Screenshots -type f -iname '*.png' | wc -l | tr -d ' ')
+          if [ "$screenshot_count" -eq 0 ]; then
+            echo "No PNG screenshots were exported from the instrumented test result bundle."
+            exit 1
+          fi
+
+          echo "Exported $screenshot_count screenshot(s)."
+
+      - name: Upload instrumented test screenshots
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: instrumented-test-results
-          path: TestResults/InstrumentedTests.xcresult
-          if-no-files-found: warn
+          name: instrumented-test-screenshots
+          path: TestResults/Screenshots/**/*.png
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload instrumented test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: instrumented-test-results
           path: TestResults/InstrumentedTests.xcresult

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,8 @@ jobs:
           mkdir -p TestResults/Screenshots
           xcrun xcresulttool export attachments \
             --path TestResults/InstrumentedTests.xcresult \
-            --output-path TestResults/Screenshots
+            --output-path TestResults/Screenshots \
+            | tee TestResults/Screenshots/export.log
           python3 .github/scripts/rename-xcresult-attachments.py \
             TestResults/InstrumentedTests.xcresult \
             TestResults/Screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,21 @@ jobs:
 
       - name: Run instrumented tests
         run: |
+          rm -rf TestResults
+          mkdir -p TestResults
           set -o pipefail
           xcodebuild test \
             -workspace Chronos.xcworkspace \
             -scheme Pandatrack \
             -destination "platform=iOS Simulator,id=${PANDATRACK_SIMULATOR_UDID}" \
+            -resultBundlePath TestResults/InstrumentedTests.xcresult \
             -only-testing:ChronosUITests \
             CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload instrumented test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-results
+          path: TestResults/InstrumentedTests.xcresult
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
           xcrun xcresulttool export attachments \
             --path TestResults/InstrumentedTests.xcresult \
             --output-path TestResults/Screenshots
+          python3 .github/scripts/rename-xcresult-attachments.py \
+            TestResults/InstrumentedTests.xcresult \
+            TestResults/Screenshots
 
           screenshot_count=$(find TestResults/Screenshots -type f -iname '*.png' | wc -l | tr -d ' ')
           if [ "$screenshot_count" -eq 0 ]; then

--- a/Chronos.xcodeproj/project.pbxproj
+++ b/Chronos.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		E9E970EC502FF307C2EF1A84 /* CurrencyAttributeSingleDeclaration+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E978464B755E7FE1C1B689 /* CurrencyAttributeSingleDeclaration+CoreDataClass.swift */; };
 		E9E971500EBECFAF2EF066CC /* SectionedFetchResults-Section+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E97D4A508D1D3AFAA211DC /* SectionedFetchResults-Section+Equatable.swift */; };
 		E9E971531449C5E522A9D282 /* ChronosUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E978FD406902D9B22A5491 /* ChronosUITests.swift */; };
+		E9EF6F4452E4830DFDD4B264 /* XCTestCase+Screenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90A6284031F62CF8DF16CD2 /* XCTestCase+Screenshot.swift */; };
 		E9E971549812460CDC236BCB /* CurrencyAttributeChoiceDeclaration+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E975FC7FCB835857DC61E9 /* CurrencyAttributeChoiceDeclaration+CoreDataClass.swift */; };
 		E9E9716DF12EDE4D85D69153 /* URLAttributeChoiceDeclaration+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E9750B9B521992766AB851 /* URLAttributeChoiceDeclaration+CoreDataClass.swift */; };
 		E9E971737E5ED2CDC138497A /* SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E97C7B859B66B31051E372 /* SampleData.swift */; };
@@ -426,6 +427,7 @@
 		E9E978CC49F166056076DBE6 /* OrderedSetBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedSetBuilder.swift; sourceTree = "<group>"; };
 		E9E978D21F854FD242E007E2 /* PercentageAttributeChoiceRelationship+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PercentageAttributeChoiceRelationship+CoreDataClass.swift"; sourceTree = "<group>"; };
 		E9E978FD406902D9B22A5491 /* ChronosUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChronosUITests.swift; sourceTree = "<group>"; };
+		E90A6284031F62CF8DF16CD2 /* XCTestCase+Screenshot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Screenshot.swift"; sourceTree = "<group>"; };
 		E9E97906E3D7918C0542D185 /* DateAttributeChoiceDeclaration+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateAttributeChoiceDeclaration+CoreDataClass.swift"; sourceTree = "<group>"; };
 		E9E979095AE3B2CAAC258BCF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E9E9792298A0F3166682C13E /* Node.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
@@ -936,6 +938,7 @@
 			children = (
 				E9E978FD406902D9B22A5491 /* ChronosUITests.swift */,
 				E9E97F8CACE703D08C017615 /* ChronosUITestsLaunchTests.swift */,
+				E90A6284031F62CF8DF16CD2 /* XCTestCase+Screenshot.swift */,
 			);
 			path = ChronosUITests;
 			sourceTree = "<group>";
@@ -1184,6 +1187,7 @@
 			files = (
 				E9E971531449C5E522A9D282 /* ChronosUITests.swift in Sources */,
 				E9E97E11658668D60FA480E3 /* ChronosUITestsLaunchTests.swift in Sources */,
+				E9EF6F4452E4830DFDD4B264 /* XCTestCase+Screenshot.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Chronos/Views/EntriesTab.swift
+++ b/Chronos/Views/EntriesTab.swift
@@ -42,7 +42,9 @@ struct EntriesTab: View {
             }
                     .searchable(text: $search)
                     .navigationTitle("Time Entries")
-                    .floatingActionButton { isPresentingEditView = true }
+                    .floatingActionButton(accessibilityIdentifier: "addEntryButton") {
+                        isPresentingEditView = true
+                    }
                     .modal("New Entry", isPresented: $isPresentingEditView, onOpen: { newEntry = CompletedEntry(moc)}) {
                         if let newEntry { EntryDetailEditView(entry: newEntry) }
                     }

--- a/Chronos/Views/FloatingActionButton.swift
+++ b/Chronos/Views/FloatingActionButton.swift
@@ -16,8 +16,9 @@ struct FloatingActionButton: View {
 
     // MARK: - Life cycle methods
 
-    init(image: Image? = nil, action: (()->())? = nil) {
+    init(image: Image? = nil, accessibilityIdentifier: String? = nil, action: (()->())? = nil) {
         self.image = image ?? Image(systemName: "plus")
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.action = action ?? {}
     }
 
@@ -35,11 +36,14 @@ struct FloatingActionButton: View {
                 .if(colorScheme == .light) { $0.colorInvert() }
                 .background(Circle().fill(Color.accentColor))
                 .accessibilityLabel("Add")
+                .ifNotNil(accessibilityIdentifier) { $0.accessibilityIdentifier($1) }
                 .padding()
     }
 
     @Environment(\.colorScheme)
     private var colorScheme: ColorScheme
+
+    private let accessibilityIdentifier: String?
 
     // MARK: - Methods
 

--- a/Chronos/Views/View+floatingActionButton.swift
+++ b/Chronos/Views/View+floatingActionButton.swift
@@ -14,14 +14,20 @@ import SwiftUI
 
 extension View {
 
-    func floatingActionButton(image: Image? = nil, action: (()->())? = nil) -> some View {
+    func floatingActionButton(
+            image: Image? = nil,
+            accessibilityIdentifier: String? = nil,
+            action: (()->())? = nil) -> some View {
         ZStack {
             self
             VStack {
                 Spacer()
                 HStack {
                     Spacer()
-                    FloatingActionButton(image: image, action: action)
+                    FloatingActionButton(
+                            image: image,
+                            accessibilityIdentifier: accessibilityIdentifier,
+                            action: action)
                 }
             }
         }

--- a/ChronosUITests/ChronosUITests.swift
+++ b/ChronosUITests/ChronosUITests.swift
@@ -120,10 +120,82 @@ extension XCTestCase {
     ///   - app: The application to capture.
     ///
     func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = name
+        let screenshot = app.screenshot()
+        let slug = ScreenshotAttachmentNames.nextSlug(from: [
+            String(describing: type(of: self)),
+            self.name,
+            name,
+        ])
+        let screenshotsDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("PandatrackUITestScreenshots", isDirectory: true)
+        let fileURL = screenshotsDirectory.appendingPathComponent("\(slug).png")
+
+        do {
+            try FileManager.default.createDirectory(at: screenshotsDirectory, withIntermediateDirectories: true)
+            try screenshot.pngRepresentation.write(to: fileURL, options: .atomic)
+        } catch {
+            XCTFail("Failed to write screenshot attachment '\(slug)': \(error)")
+            return
+        }
+
+        let attachment = XCTAttachment(contentsOfFile: fileURL)
+        attachment.name = slug
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+}
+
+
+// MARK: - Screenshot attachment names
+
+private enum ScreenshotAttachmentNames {
+
+    // MARK: - Static properties
+
+    private static let lock = NSLock()
+    private static var counts: [String: Int] = [:]
+
+    // MARK: - Static methods
+
+    static func nextSlug(from components: [String]) -> String {
+        let baseSlug = components.joined(separator: "-").slugified()
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        let count = (counts[baseSlug] ?? 0) + 1
+        counts[baseSlug] = count
+
+        if count == 1 { return baseSlug }
+        return "\(baseSlug)-\(count)"
+    }
+
+}
+
+
+// MARK: - String slugification
+
+private extension String {
+
+    // MARK: - Methods
+
+    func slugified() -> String {
+        let allowedCharacters = CharacterSet.alphanumerics
+        var slug = ""
+        var lastCharacterWasDash = false
+
+        for scalar in lowercased().unicodeScalars {
+            if allowedCharacters.contains(scalar) {
+                slug.append(Character(scalar))
+                lastCharacterWasDash = false
+            } else if !lastCharacterWasDash {
+                slug.append("-")
+                lastCharacterWasDash = true
+            }
+        }
+
+        return slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
     }
 
 }

--- a/ChronosUITests/ChronosUITests.swift
+++ b/ChronosUITests/ChronosUITests.swift
@@ -66,6 +66,23 @@ class ChronosUITests: XCTestCase {
                 .matching(NSPredicate(format: "label == 'Entry' AND value == %@", Self.entryName))
                 .firstMatch
         XCTAssertTrue(entry.waitForExistence(timeout: 5))
+
+        addScreenshotAttachment(named: "Created Time Entry", from: app)
+    }
+
+    /// Show the add-entry form through the real application UI.
+    ///
+    /// - Throws:
+    ///
+    func testShowsAddEntryForm() throws {
+        let app = makeApp(resetPersistentStore: true)
+        app.launch()
+
+        XCTAssertTrue(app.navigationBars["Time Entries"].waitForExistence(timeout: 5))
+        app.buttons["Add"].tap()
+
+        XCTAssertTrue(app.textFields["Name"].waitForExistence(timeout: 5))
+        addScreenshotAttachment(named: "Add Time Entry Form", from: app)
     }
 
     /// Measure how long it takes to launch the application.
@@ -85,6 +102,28 @@ class ChronosUITests: XCTestCase {
         app.launchArguments.append("--ui-testing")
         if resetPersistentStore { app.launchArguments.append("--reset-persistent-store") }
         return app
+    }
+
+}
+
+
+// MARK: - Screenshot attachments
+
+extension XCTestCase {
+
+    // MARK: - Methods
+
+    /// Add a screenshot attachment that is retained in the test result bundle.
+    ///
+    /// - Parameters:
+    ///   - name: The attachment name shown in the test result bundle.
+    ///   - app: The application to capture.
+    ///
+    func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
     }
 
 }

--- a/ChronosUITests/ChronosUITests.swift
+++ b/ChronosUITests/ChronosUITests.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UIKit
 import XCTest
 
 
@@ -68,7 +67,7 @@ class ChronosUITests: XCTestCase {
                 .firstMatch
         XCTAssertTrue(entry.waitForExistence(timeout: 5))
 
-        addScreenshotAttachment(named: "Created Time Entry", from: app)
+        addScreenshotAttachment(named: "created-time-entry", from: app)
     }
 
     /// Show the add-entry form through the real application UI.
@@ -83,7 +82,7 @@ class ChronosUITests: XCTestCase {
         app.buttons["Add"].tap()
 
         XCTAssertTrue(app.textFields["Name"].waitForExistence(timeout: 5))
-        addScreenshotAttachment(named: "Add Time Entry Form", from: app)
+        addScreenshotAttachment(named: "add-time-entry-form", from: app)
     }
 
     /// Measure how long it takes to launch the application.
@@ -103,64 +102,6 @@ class ChronosUITests: XCTestCase {
         app.launchArguments.append("--ui-testing")
         if resetPersistentStore { app.launchArguments.append("--reset-persistent-store") }
         return app
-    }
-
-}
-
-
-// MARK: - Screenshot attachments
-
-extension XCTestCase {
-
-    // MARK: - Methods
-
-    /// Add a screenshot attachment that is retained in the test result bundle.
-    ///
-    /// - Parameters:
-    ///   - name: The attachment name shown in the test result bundle.
-    ///   - app: The application to capture.
-    ///
-    func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
-        addScreenshotAttachment(named: name, screenshot: app.screenshot())
-    }
-
-    /// Add a screenshot attachment that is retained in the test result bundle.
-    ///
-    /// - Parameters:
-    ///   - name: The attachment name shown in the test result bundle.
-    ///   - screenshot: The screenshot to attach.
-    ///
-    func addScreenshotAttachment(named name: String, screenshot: XCUIScreenshot) {
-        let attachment = XCTAttachment(screenshot: screenshot)
-        attachment.name = name
-        attachment.lifetime = .keepAlways
-        add(attachment)
-    }
-
-}
-
-
-// MARK: - Screenshot orientation
-
-extension XCUIScreenshot {
-
-    // MARK: - Properties
-
-    var pandatrackOrientationName: String {
-        guard let size = pngPixelSize else {
-            return image.size.width > image.size.height ? "Landscape" : "Portrait"
-        }
-
-        return size.width > size.height ? "Landscape" : "Portrait"
-    }
-
-    private var pngPixelSize: (width: Int, height: Int)? {
-        let bytes = [UInt8](pngRepresentation)
-        guard bytes.count >= 24 else { return nil }
-
-        let width = (Int(bytes[16]) << 24) | (Int(bytes[17]) << 16) | (Int(bytes[18]) << 8) | Int(bytes[19])
-        let height = (Int(bytes[20]) << 24) | (Int(bytes[21]) << 16) | (Int(bytes[22]) << 8) | Int(bytes[23])
-        return (width, height)
     }
 
 }

--- a/ChronosUITests/ChronosUITests.swift
+++ b/ChronosUITests/ChronosUITests.swift
@@ -53,7 +53,9 @@ class ChronosUITests: XCTestCase {
         XCTAssertTrue(app.navigationBars["Time Entries"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Hi, I‘m Pandy!"].exists)
 
-        app.buttons["Add"].tap()
+        let addEntryButton = app.buttons["addEntryButton"]
+        XCTAssertTrue(addEntryButton.waitForExistence(timeout: 5))
+        addEntryButton.tap()
 
         let nameField = app.textFields["Name"]
         XCTAssertTrue(nameField.waitForExistence(timeout: 5))
@@ -79,7 +81,10 @@ class ChronosUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.navigationBars["Time Entries"].waitForExistence(timeout: 5))
-        app.buttons["Add"].tap()
+
+        let addEntryButton = app.buttons["addEntryButton"]
+        XCTAssertTrue(addEntryButton.waitForExistence(timeout: 5))
+        addEntryButton.tap()
 
         XCTAssertTrue(app.textFields["Name"].waitForExistence(timeout: 5))
         addScreenshotAttachment(named: "add-time-entry-form", from: app)

--- a/ChronosUITests/ChronosUITests.swift
+++ b/ChronosUITests/ChronosUITests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import XCTest
 
 
@@ -120,26 +121,18 @@ extension XCTestCase {
     ///   - app: The application to capture.
     ///
     func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
-        let screenshot = app.screenshot()
-        let slug = ScreenshotAttachmentNames.nextSlug(from: [
-            String(describing: type(of: self)),
-            self.name,
-            name,
-        ])
-        let screenshotsDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-                .appendingPathComponent("PandatrackUITestScreenshots", isDirectory: true)
-        let fileURL = screenshotsDirectory.appendingPathComponent("\(slug).png")
+        addScreenshotAttachment(named: name, screenshot: app.screenshot())
+    }
 
-        do {
-            try FileManager.default.createDirectory(at: screenshotsDirectory, withIntermediateDirectories: true)
-            try screenshot.pngRepresentation.write(to: fileURL, options: .atomic)
-        } catch {
-            XCTFail("Failed to write screenshot attachment '\(slug)': \(error)")
-            return
-        }
-
-        let attachment = XCTAttachment(contentsOfFile: fileURL)
-        attachment.name = slug
+    /// Add a screenshot attachment that is retained in the test result bundle.
+    ///
+    /// - Parameters:
+    ///   - name: The attachment name shown in the test result bundle.
+    ///   - screenshot: The screenshot to attach.
+    ///
+    func addScreenshotAttachment(named name: String, screenshot: XCUIScreenshot) {
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
     }
@@ -147,55 +140,14 @@ extension XCTestCase {
 }
 
 
-// MARK: - Screenshot attachment names
+// MARK: - Screenshot orientation
 
-private enum ScreenshotAttachmentNames {
+extension XCUIScreenshot {
 
-    // MARK: - Static properties
+    // MARK: - Properties
 
-    private static let lock = NSLock()
-    private static var counts: [String: Int] = [:]
-
-    // MARK: - Static methods
-
-    static func nextSlug(from components: [String]) -> String {
-        let baseSlug = components.joined(separator: "-").slugified()
-
-        lock.lock()
-        defer { lock.unlock() }
-
-        let count = (counts[baseSlug] ?? 0) + 1
-        counts[baseSlug] = count
-
-        if count == 1 { return baseSlug }
-        return "\(baseSlug)-\(count)"
-    }
-
-}
-
-
-// MARK: - String slugification
-
-private extension String {
-
-    // MARK: - Methods
-
-    func slugified() -> String {
-        let allowedCharacters = CharacterSet.alphanumerics
-        var slug = ""
-        var lastCharacterWasDash = false
-
-        for scalar in lowercased().unicodeScalars {
-            if allowedCharacters.contains(scalar) {
-                slug.append(Character(scalar))
-                lastCharacterWasDash = false
-            } else if !lastCharacterWasDash {
-                slug.append("-")
-                lastCharacterWasDash = true
-            }
-        }
-
-        return slug.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    var pandatrackOrientationName: String {
+        image.size.width > image.size.height ? "Landscape" : "Portrait"
     }
 
 }

--- a/ChronosUITests/ChronosUITests.swift
+++ b/ChronosUITests/ChronosUITests.swift
@@ -147,7 +147,20 @@ extension XCUIScreenshot {
     // MARK: - Properties
 
     var pandatrackOrientationName: String {
-        image.size.width > image.size.height ? "Landscape" : "Portrait"
+        guard let size = pngPixelSize else {
+            return image.size.width > image.size.height ? "Landscape" : "Portrait"
+        }
+
+        return size.width > size.height ? "Landscape" : "Portrait"
+    }
+
+    private var pngPixelSize: (width: Int, height: Int)? {
+        let bytes = [UInt8](pngRepresentation)
+        guard bytes.count >= 24 else { return nil }
+
+        let width = (Int(bytes[16]) << 24) | (Int(bytes[17]) << 16) | (Int(bytes[18]) << 8) | Int(bytes[19])
+        let height = (Int(bytes[20]) << 24) | (Int(bytes[21]) << 16) | (Int(bytes[22]) << 8) | Int(bytes[23])
+        return (width, height)
     }
 
 }

--- a/ChronosUITests/ChronosUITestsLaunchTests.swift
+++ b/ChronosUITests/ChronosUITestsLaunchTests.swift
@@ -63,10 +63,7 @@ class ChronosUITestsLaunchTests: XCTestCase {
         app.launchArguments.append("--reset-persistent-store")
         app.launch()
 
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "Launch Screen"
-        attachment.lifetime = .keepAlways
-        add(attachment)
+        addScreenshotAttachment(named: "Launch Screen", from: app)
     }
 
 }

--- a/ChronosUITests/ChronosUITestsLaunchTests.swift
+++ b/ChronosUITests/ChronosUITestsLaunchTests.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UIKit
 import XCTest
 
 
@@ -64,8 +63,7 @@ class ChronosUITestsLaunchTests: XCTestCase {
         app.launchArguments.append("--reset-persistent-store")
         app.launch()
 
-        let screenshot = app.screenshot()
-        addScreenshotAttachment(named: "Launch Screen \(screenshot.pandatrackOrientationName)", screenshot: screenshot)
+        addScreenshotAttachment(named: "launch-screen", from: app)
     }
 
 }

--- a/ChronosUITests/ChronosUITestsLaunchTests.swift
+++ b/ChronosUITests/ChronosUITestsLaunchTests.swift
@@ -64,11 +64,8 @@ class ChronosUITestsLaunchTests: XCTestCase {
         app.launchArguments.append("--reset-persistent-store")
         app.launch()
 
-        // The screenshot exporter currently produces cropped, black-padded images for landscape launch captures.
-        // Keep the launch coverage for every UI configuration, but only retain readable portrait screenshots.
-        guard !XCUIDevice.shared.orientation.isLandscape else { return }
-
-        addScreenshotAttachment(named: "Launch Screen", from: app)
+        let screenshot = app.screenshot()
+        addScreenshotAttachment(named: "Launch Screen \(screenshot.pandatrackOrientationName)", screenshot: screenshot)
     }
 
 }

--- a/ChronosUITests/ChronosUITestsLaunchTests.swift
+++ b/ChronosUITests/ChronosUITestsLaunchTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import XCTest
 
 
@@ -62,6 +63,10 @@ class ChronosUITestsLaunchTests: XCTestCase {
         app.launchArguments.append("--ui-testing")
         app.launchArguments.append("--reset-persistent-store")
         app.launch()
+
+        // The screenshot exporter currently produces cropped, black-padded images for landscape launch captures.
+        // Keep the launch coverage for every UI configuration, but only retain readable portrait screenshots.
+        guard !XCUIDevice.shared.orientation.isLandscape else { return }
 
         addScreenshotAttachment(named: "Launch Screen", from: app)
     }

--- a/ChronosUITests/XCTestCase+Screenshot.swift
+++ b/ChronosUITests/XCTestCase+Screenshot.swift
@@ -20,8 +20,8 @@ extension XCTestCase {
     ///   - name: The base slug for the attachment name shown in the test result bundle.
     ///   - app: The application to capture.
     ///
-    func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
-        let screenshot = app.screenshot()
+    func addScreenshotAttachment(named name: String, from _: XCUIApplication) {
+        let screenshot = XCUIScreen.main.screenshot()
         let orientation = screenshot.pngPixelSize.width > screenshot.pngPixelSize.height ? "landscape" : "portrait"
         let attachment = XCTAttachment(screenshot: screenshot)
         attachment.name = "\(name)-\(orientation)"

--- a/ChronosUITests/XCTestCase+Screenshot.swift
+++ b/ChronosUITests/XCTestCase+Screenshot.swift
@@ -22,11 +22,29 @@ extension XCTestCase {
     ///
     func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
         let screenshot = app.screenshot()
-        let orientation = screenshot.image.size.width > screenshot.image.size.height ? "landscape" : "portrait"
+        let orientation = screenshot.pngPixelSize.width > screenshot.pngPixelSize.height ? "landscape" : "portrait"
         let attachment = XCTAttachment(screenshot: screenshot)
         attachment.name = "\(name)-\(orientation)"
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+}
+
+
+// MARK: - Screenshot dimensions
+
+private extension XCUIScreenshot {
+
+    // MARK: - Properties
+
+    var pngPixelSize: (width: Int, height: Int) {
+        let bytes = [UInt8](pngRepresentation)
+        guard bytes.count >= 24 else { return (Int(image.size.width), Int(image.size.height)) }
+
+        let width = (Int(bytes[16]) << 24) | (Int(bytes[17]) << 16) | (Int(bytes[18]) << 8) | Int(bytes[19])
+        let height = (Int(bytes[20]) << 24) | (Int(bytes[21]) << 16) | (Int(bytes[22]) << 8) | Int(bytes[23])
+        return (width, height)
     }
 
 }

--- a/ChronosUITests/XCTestCase+Screenshot.swift
+++ b/ChronosUITests/XCTestCase+Screenshot.swift
@@ -44,8 +44,7 @@ private extension XCUIScreenshot {
     var pngDataForCurrentOrientation: Data {
         let pngData = pngRepresentation
         guard XCUIDevice.shared.orientation.isLandscape,
-              let image = UIImage(data: pngData),
-              let rotatedData = image.rotatedForLandscapeScreenshot.pngData()
+              let rotatedData = UIImage(data: pngData)?.landscapeScreenshotPNGData
         else { return pngData }
 
         return rotatedData
@@ -60,15 +59,26 @@ private extension UIImage {
 
     // MARK: - Properties
 
-    var rotatedForLandscapeScreenshot: UIImage {
-        let rotatedSize = CGSize(width: size.height, height: size.width)
-        let renderer = UIGraphicsImageRenderer(size: rotatedSize)
+    var landscapeScreenshotPNGData: Data? {
+        guard let cgImage else { return nil }
+
+        let imageSize = CGSize(width: cgImage.width, height: cgImage.height)
+        let rotatedSize = CGSize(width: imageSize.height, height: imageSize.width)
+        let rendererFormat = UIGraphicsImageRendererFormat()
+        rendererFormat.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: rotatedSize, format: rendererFormat)
+        let drawRect = CGRect(
+                x: -imageSize.width / 2,
+                y: -imageSize.height / 2,
+                width: imageSize.width,
+                height: imageSize.height
+        )
         return renderer.image { context in
             let cgContext = context.cgContext
             cgContext.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
             cgContext.rotate(by: .pi / 2)
-            draw(in: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height))
-        }
+            UIImage(cgImage: cgImage).draw(in: drawRect)
+        }.pngData()
     }
 
 }

--- a/ChronosUITests/XCTestCase+Screenshot.swift
+++ b/ChronosUITests/XCTestCase+Screenshot.swift
@@ -5,6 +5,7 @@
 //  Created by Jean-Pierre Höhmann on 2022-09-08.
 //
 
+import UIKit
 import XCTest
 
 
@@ -22,8 +23,10 @@ extension XCTestCase {
     ///
     func addScreenshotAttachment(named name: String, from _: XCUIApplication) {
         let screenshot = XCUIScreen.main.screenshot()
-        let orientation = screenshot.pngPixelSize.width > screenshot.pngPixelSize.height ? "landscape" : "portrait"
-        let attachment = XCTAttachment(screenshot: screenshot)
+        let pngData = screenshot.pngDataForCurrentOrientation
+        let pixelSize = pngData.pngPixelSize
+        let orientation = pixelSize.width > pixelSize.height ? "landscape" : "portrait"
+        let attachment = XCTAttachment(data: pngData, uniformTypeIdentifier: "public.png")
         attachment.name = "\(name)-\(orientation)"
         attachment.lifetime = .keepAlways
         add(attachment)
@@ -32,15 +35,54 @@ extension XCTestCase {
 }
 
 
-// MARK: - Screenshot dimensions
+// MARK: - Screenshot data
 
 private extension XCUIScreenshot {
 
     // MARK: - Properties
 
+    var pngDataForCurrentOrientation: Data {
+        let pngData = pngRepresentation
+        guard XCUIDevice.shared.orientation.isLandscape,
+              let image = UIImage(data: pngData),
+              let rotatedData = image.rotatedForLandscapeScreenshot.pngData()
+        else { return pngData }
+
+        return rotatedData
+    }
+
+}
+
+
+// MARK: - Screenshot rotation
+
+private extension UIImage {
+
+    // MARK: - Properties
+
+    var rotatedForLandscapeScreenshot: UIImage {
+        let rotatedSize = CGSize(width: size.height, height: size.width)
+        let renderer = UIGraphicsImageRenderer(size: rotatedSize)
+        return renderer.image { context in
+            let cgContext = context.cgContext
+            cgContext.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
+            cgContext.rotate(by: .pi / 2)
+            draw(in: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height))
+        }
+    }
+
+}
+
+
+// MARK: - PNG dimensions
+
+private extension Data {
+
+    // MARK: - Properties
+
     var pngPixelSize: (width: Int, height: Int) {
-        let bytes = [UInt8](pngRepresentation)
-        guard bytes.count >= 24 else { return (Int(image.size.width), Int(image.size.height)) }
+        let bytes = [UInt8](self)
+        guard bytes.count >= 24 else { return (0, 0) }
 
         let width = (Int(bytes[16]) << 24) | (Int(bytes[17]) << 16) | (Int(bytes[18]) << 8) | Int(bytes[19])
         let height = (Int(bytes[20]) << 24) | (Int(bytes[21]) << 16) | (Int(bytes[22]) << 8) | Int(bytes[23])

--- a/ChronosUITests/XCTestCase+Screenshot.swift
+++ b/ChronosUITests/XCTestCase+Screenshot.swift
@@ -1,0 +1,32 @@
+//
+//  XCTestCase+Screenshot.swift
+//  ChronosUITests
+//
+//  Created by Jean-Pierre Höhmann on 2022-09-08.
+//
+
+import XCTest
+
+
+// MARK: - Screenshot attachments
+
+extension XCTestCase {
+
+    // MARK: - Methods
+
+    /// Add a screenshot attachment that is retained in the test result bundle.
+    ///
+    /// - Parameters:
+    ///   - name: The base slug for the attachment name shown in the test result bundle.
+    ///   - app: The application to capture.
+    ///
+    func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
+        let screenshot = app.screenshot()
+        let orientation = screenshot.image.size.width > screenshot.image.size.height ? "landscape" : "portrait"
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = "\(name)-\(orientation)"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+}

--- a/ChronosUITests/XCTestCase+Screenshot.swift
+++ b/ChronosUITests/XCTestCase+Screenshot.swift
@@ -21,15 +21,101 @@ extension XCTestCase {
     ///   - name: The base slug for the attachment name shown in the test result bundle.
     ///   - app: The application to capture.
     ///
-    func addScreenshotAttachment(named name: String, from _: XCUIApplication) {
+    func addScreenshotAttachment(named name: String, from app: XCUIApplication) {
         let screenshot = XCUIScreen.main.screenshot()
         let pngData = screenshot.pngDataForCurrentOrientation
         let pixelSize = pngData.pngPixelSize
         let orientation = pixelSize.width > pixelSize.height ? "landscape" : "portrait"
+        let configuration = app.targetApplicationUIConfigurationScreenshotNameComponent
         let attachment = XCTAttachment(data: pngData, uniformTypeIdentifier: "public.png")
-        attachment.name = "\(name)-\(orientation)"
+        attachment.name = "\(name)-\(configuration)-\(orientation)"
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+}
+
+
+// MARK: - Target application UI configuration
+
+private extension XCUIApplication {
+
+    // MARK: - Properties
+
+    var targetApplicationUIConfigurationScreenshotNameComponent: String {
+        let traits = UIScreen.main.traitCollection
+        return [
+            "style-\(traits.userInterfaceStyle.screenshotNameComponent)",
+            "content-size-\(contentSizeCategoryScreenshotNameComponent(from: traits))",
+            "languages-\(languagesScreenshotNameComponent)",
+            "locale-\(localeScreenshotNameComponent)"
+        ].joined(separator: "-")
+    }
+
+    private var languagesScreenshotNameComponent: String {
+        launchArgumentValue(after: "-AppleLanguages")?.screenshotNameComponent
+                ?? Locale.preferredLanguages.joined(separator: ",").screenshotNameComponent
+    }
+
+    private var localeScreenshotNameComponent: String {
+        launchArgumentValue(after: "-AppleLocale")?.screenshotNameComponent
+                ?? Locale.current.identifier.screenshotNameComponent
+    }
+
+    // MARK: - Methods
+
+    private func contentSizeCategoryScreenshotNameComponent(from traits: UITraitCollection) -> String {
+        launchArgumentValue(after: "-UIPreferredContentSizeCategoryName")?.screenshotNameComponent
+                ?? traits.preferredContentSizeCategory.rawValue.screenshotNameComponent
+    }
+
+    private func launchArgumentValue(after option: String) -> String? {
+        guard let optionIndex = launchArguments.firstIndex(of: option) else { return nil }
+
+        let valueIndex = launchArguments.index(after: optionIndex)
+        guard valueIndex < launchArguments.endIndex else { return nil }
+
+        return launchArguments[valueIndex]
+    }
+
+}
+
+
+// MARK: - Interface style names
+
+private extension UIUserInterfaceStyle {
+
+    // MARK: - Properties
+
+    var screenshotNameComponent: String {
+        switch self {
+        case .unspecified:
+            return "unspecified"
+        case .light:
+            return "light"
+        case .dark:
+            return "dark"
+        @unknown default:
+            return "unknown-\(rawValue)"
+        }
+    }
+
+}
+
+
+// MARK: - Screenshot name components
+
+private extension String {
+
+    // MARK: - Properties
+
+    var screenshotNameComponent: String {
+        let components = lowercased()
+                .split { !$0.isLetter && !$0.isNumber }
+                .map(String.init)
+        guard !components.isEmpty else { return "unspecified" }
+
+        return components.joined(separator: "-")
     }
 
 }


### PR DESCRIPTION
closes valomedia/Pandatrack#24

Updated the instrumented-tests workflow to write an Xcode result bundle at TestResults/InstrumentedTests.xcresult and upload it with actions/upload-artifact@v4 so retained XCTest screenshot attachments are available from GitHub Actions. Added retained screenshots to three UI tests: the launch test, the create-entry test, and a new add-entry-form test, with screenshot attachment creation shared through a XCTestCase helper. Verification: ran git diff --check, parsed the workflow YAML and verified the artifact upload configuration, and ran direct Python checks confirming the result bundle path plus three screenshot-producing UI test methods. Xcode/xcodebuild and Swift verification were unavailable in this Linux container. Committed changes as 88cc87a test: add UI test screenshot artifacts.