### PR TITLE
Remove fork PR skip checks from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
   build:
     name: Build
     runs-on: macos-15
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout
@@ -43,7 +42,6 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: macos-15
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout
@@ -73,7 +71,6 @@ jobs:
   instrumented-tests:
     name: Instrumented Tests
     runs-on: macos-15
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout


### PR DESCRIPTION
closes valomedia/Pandatrack#23

Removed the redundant repository-local fork/cross-repo pull request skip conditions from all three CI jobs in .github/workflows/ci.yml (build, unit-tests, and instrumented-tests), leaving the ordinary pull_request and push triggers intact so org-level workflow approval policy controls dangerous cross-repo PR execution. Verified the workflow YAML parses with Python/PyYAML, confirmed the pull_request trigger remains present, confirmed the removed fork-skip expressions are absent, and checked the working tree is clean after committing with message: ci: remove fork PR skip checks.