### PR TITLE
Add dedicated CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,29 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: macos-15
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Install CocoaPods dependencies
+        run: pod install --repo-update
+
+      - name: Create iOS simulator
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/create-ios-simulator.py "Pandatrack CI iPhone"
+
+      - name: Run static analysis
+        run: ./scripts/lint.sh
+
   build:
     name: Build
     runs-on: macos-15

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ Install CocoaPods dependencies before opening the project:
 pod install --repo-update
 open Chronos.xcworkspace
 ```
+
+Run Xcode static analysis with the repository-local lint command:
+
+```sh
+./scripts/lint.sh
+```

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#
+# lint.sh
+# Pandatrack
+#
+# Run the repository's Xcode static-analysis gate.
+#
+
+set -euo pipefail
+
+SRCROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -n "${PANDATRACK_SIMULATOR_UDID:-}" ]]; then
+  DESTINATION="platform=iOS Simulator,id=${PANDATRACK_SIMULATOR_UDID}"
+else
+  DESTINATION="${PANDATRACK_LINT_DESTINATION:-generic/platform=iOS Simulator}"
+fi
+
+cd "${SRCROOT}"
+
+xcodebuild analyze \
+  -workspace Chronos.xcworkspace \
+  -scheme Pandatrack \
+  -destination "${DESTINATION}" \
+  CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
closes valomedia/Pandatrack#18

Added a dedicated CI lint job that follows the existing macos-15/Xcode/CocoaPods/simulator setup and preserves the current trigger and fork-PR policy. Added scripts/lint.sh as the repository-local static-analysis command, running xcodebuild analyze for the Pandatrack workspace/scheme with the CI simulator UDID when available and a generic iOS Simulator destination otherwise. Documented the lint command in README.md. Verification: ran bash -n scripts/lint.sh, git diff --check, and a Python workflow/script validation that parsed .github/workflows/ci.yml, checked the lint job shape and policy, verified scripts/lint.sh is executable, and stub-tested the xcodebuild invocation for both default and CI simulator destinations. actionlint and xcodebuild were unavailable in this Linux environment. Committed changes as 65360fa ci: add dedicated lint job.