### PR TITLE
Export ad-hoc IPA from CI

### DIFF
--- a/.github/scripts/configure-ios-signing.py
+++ b/.github/scripts/configure-ios-signing.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Apply CI-only manual signing settings to the app target."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+SETTING_FORMATS = {
+    "CODE_SIGN_STYLE": "Manual",
+}
+
+
+def quote_build_setting(value: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_.$()/]+", value):
+        return value
+
+    return '"' + value.replace('\\', '\\\\').replace('"', '\\"') + '"'
+
+
+def build_setting_value(key: str, value: str) -> str:
+    return SETTING_FORMATS.get(key, quote_build_setting(value))
+
+
+def configuration_blocks(project: str) -> list[tuple[int, int]]:
+    blocks: list[tuple[int, int]] = []
+    search_start = 0
+
+    while True:
+        marker = project.find("isa = XCBuildConfiguration;", search_start)
+        if marker == -1:
+            return blocks
+
+        block_start = project.rfind("\n", 0, marker) + 1
+        block_start = project.rfind("\n", 0, block_start - 1) + 1
+        opening_brace = project.find("{", block_start, marker)
+        if opening_brace == -1:
+            raise SystemExit("Could not find build configuration opening brace.")
+
+        depth = 0
+        block_end = None
+        for index in range(opening_brace, len(project)):
+            character = project[index]
+            if character == "{":
+                depth += 1
+            elif character == "}":
+                depth -= 1
+                if depth == 0:
+                    block_end = index + 2
+                    break
+
+        if block_end is None:
+            raise SystemExit("Could not find build configuration closing brace.")
+
+        blocks.append((block_start, block_end))
+        search_start = block_end
+
+
+def update_build_setting(block: str, key: str, value: str) -> str:
+    formatted_value = build_setting_value(key, value)
+    setting_pattern = re.compile(rf"^(\s*){re.escape(key)} = .*;$", re.MULTILINE)
+    match = setting_pattern.search(block)
+    if match:
+        return setting_pattern.sub(
+            rf"\1{key} = {formatted_value};",
+            block,
+            count=1,
+        )
+
+    build_settings_end = block.rfind("\n\t\t\t};")
+    if build_settings_end == -1:
+        raise SystemExit("Could not find buildSettings closing brace.")
+
+    return block[:build_settings_end] + f"\n\t\t\t\t{key} = {formatted_value};" + block[build_settings_end:]
+
+
+def configure_project(
+    project: str,
+    bundle_identifier: str,
+    team_id: str,
+    profile_name: str,
+    signing_identity: str,
+) -> tuple[str, int]:
+    settings = {
+        "CODE_SIGN_IDENTITY": signing_identity,
+        "CODE_SIGN_STYLE": "Manual",
+        "DEVELOPMENT_TEAM": team_id,
+        "PROVISIONING_PROFILE_SPECIFIER": profile_name,
+    }
+    updated_project_parts: list[str] = []
+    last_index = 0
+    updated_count = 0
+
+    for block_start, block_end in configuration_blocks(project):
+        block = project[block_start:block_end]
+        updated_project_parts.append(project[last_index:block_start])
+
+        if f"PRODUCT_BUNDLE_IDENTIFIER = {bundle_identifier};" in block:
+            for key, value in settings.items():
+                block = update_build_setting(block, key, value)
+            updated_count += 1
+
+        updated_project_parts.append(block)
+        last_index = block_end
+    updated_project_parts.append(project[last_index:])
+
+    return "".join(updated_project_parts), updated_count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("project_file", type=Path)
+    parser.add_argument("--bundle-identifier", required=True)
+    parser.add_argument("--team-id", required=True)
+    parser.add_argument("--profile-name", required=True)
+    parser.add_argument("--signing-identity", required=True)
+    args = parser.parse_args()
+
+    project = args.project_file.read_text(encoding="utf-8")
+    updated_project, updated_count = configure_project(
+        project,
+        bundle_identifier=args.bundle_identifier,
+        team_id=args.team_id,
+        profile_name=args.profile_name,
+        signing_identity=args.signing_identity,
+    )
+
+    if updated_count == 0:
+        raise SystemExit(
+            f"No build configurations found for bundle identifier {args.bundle_identifier}."
+        )
+
+    args.project_file.write_text(updated_project, encoding="utf-8")
+    print(
+        "Configured manual signing for "
+        f"{updated_count} app build configuration(s) using {args.profile_name}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/select-ios-signing-identity.py
+++ b/.github/scripts/select-ios-signing-identity.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Select an imported code-signing identity included in a provisioning profile."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+IDENTITY_PATTERN = re.compile(r'\)\s+([0-9A-Fa-f]{40})\s+"(.+)"')
+
+
+def certificate_sha1(certificate: bytes) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".cer", delete=False) as certificate_file:
+        certificate_file.write(certificate)
+        certificate_path = Path(certificate_file.name)
+
+    try:
+        result = subprocess.run(
+            [
+                "openssl",
+                "x509",
+                "-inform",
+                "DER",
+                "-in",
+                str(certificate_path),
+                "-noout",
+                "-fingerprint",
+                "-sha1",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        certificate_path.unlink(missing_ok=True)
+
+    return result.stdout.split("=", 1)[1].replace(":", "").strip().upper()
+
+
+def profile_certificate_hashes(profile_plist: Path) -> set[str]:
+    with profile_plist.open("rb") as profile_file:
+        profile = plistlib.load(profile_file)
+
+    return {
+        certificate_sha1(certificate)
+        for certificate in profile.get("DeveloperCertificates", [])
+    }
+
+
+def imported_identities(identities_path: Path) -> list[tuple[str, str]]:
+    identities: list[tuple[str, str]] = []
+    for line in identities_path.read_text(encoding="utf-8").splitlines():
+        match = IDENTITY_PATTERN.search(line)
+        if match:
+            identities.append((match.group(1).upper(), match.group(2)))
+    return identities
+
+
+def write_github_env(key: str, value: str) -> None:
+    github_env = os.environ.get("GITHUB_ENV")
+    if github_env:
+        with Path(github_env).open("a", encoding="utf-8") as env_file:
+            env_file.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: select-ios-signing-identity.py PROFILE_PLIST IDENTITIES_FILE")
+
+    profile_hashes = profile_certificate_hashes(Path(sys.argv[1]))
+    identities = imported_identities(Path(sys.argv[2]))
+    matching_identities = [identity for identity in identities if identity[0] in profile_hashes]
+
+    if not matching_identities:
+        print(
+            "::error::The ad-hoc provisioning profile does not include any "
+            "imported code-signing identity."
+        )
+        print(
+            "::error::Update IOS_ADHOC_PROVISIONING_PROFILE_BASE64 so it includes "
+            "the certificate from IOS_DISTRIBUTION_CERTIFICATE_BASE64, or import "
+            "the distribution certificate that is already included in the profile."
+        )
+        raise SystemExit(1)
+
+    selected_sha1, selected_name = next(
+        (
+            identity
+            for identity in matching_identities
+            if "Distribution" in identity[1]
+        ),
+        matching_identities[0],
+    )
+    write_github_env("PANDATRACK_CODE_SIGN_IDENTITY", selected_name)
+    write_github_env("PANDATRACK_CODE_SIGN_IDENTITY_SHA1", selected_sha1)
+    print(f"Selected signing identity {selected_name}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,157 @@ jobs:
             -destination "platform=iOS Simulator,id=${PANDATRACK_SIMULATOR_UDID}" \
             -only-testing:ChronosUITests \
             CODE_SIGNING_ALLOWED=NO
+
+  export-ad-hoc-ipa:
+    name: Export Ad-Hoc IPA
+    runs-on: macos-15
+    needs:
+      - build
+      - unit-tests
+      - instrumented-tests
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Install CocoaPods dependencies
+        run: pod install --repo-update
+
+      - name: Import signing certificate
+        env:
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/ios_distribution_certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/pandatrack-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+
+          printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH" \
+            -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security \
+            -T /usr/bin/xcodebuild
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          {
+            echo "PANDATRACK_SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
+            echo "PANDATRACK_CERTIFICATE_PATH=$CERTIFICATE_PATH"
+          } >> "$GITHUB_ENV"
+
+      - name: Install ad-hoc provisioning profile
+        env:
+          IOS_ADHOC_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_ADHOC_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          PROFILE_PATH="$RUNNER_TEMP/pandatrack-adhoc.mobileprovision"
+          PROFILE_PLIST="$RUNNER_TEMP/pandatrack-adhoc.plist"
+          PROFILE_INSTALL_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+
+          printf '%s' "$IOS_ADHOC_PROVISIONING_PROFILE_BASE64" | base64 -D > "$PROFILE_PATH"
+          security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
+
+          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PROFILE_PLIST")"
+          PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")"
+          TEAM_ID="$(/usr/libexec/PlistBuddy -c 'Print TeamIdentifier:0' "$PROFILE_PLIST")"
+          APPLICATION_IDENTIFIER="$(/usr/libexec/PlistBuddy -c 'Print Entitlements:application-identifier' "$PROFILE_PLIST")"
+          BUNDLE_IDENTIFIER="${APPLICATION_IDENTIFIER#${TEAM_ID}.}"
+
+          mkdir -p "$PROFILE_INSTALL_DIR"
+          cp "$PROFILE_PATH" "$PROFILE_INSTALL_DIR/$PROFILE_UUID.mobileprovision"
+
+          {
+            echo "IOS_ADHOC_PROVISIONING_PROFILE_UUID=$PROFILE_UUID"
+            echo "IOS_ADHOC_PROVISIONING_PROFILE_NAME=$PROFILE_NAME"
+            echo "IOS_ADHOC_PROVISIONING_PROFILE_PATH=$PROFILE_INSTALL_DIR/$PROFILE_UUID.mobileprovision"
+            echo "IOS_DEVELOPMENT_TEAM_ID=$TEAM_ID"
+            echo "PANDATRACK_BUNDLE_IDENTIFIER=$BUNDLE_IDENTIFIER"
+          } >> "$GITHUB_ENV"
+
+      - name: Archive app
+        run: |
+          set -o pipefail
+          xcodebuild archive \
+            -workspace Chronos.xcworkspace \
+            -scheme Pandatrack \
+            -destination "generic/platform=iOS" \
+            -archivePath "$RUNNER_TEMP/Pandatrack.xcarchive" \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="$IOS_DEVELOPMENT_TEAM_ID" \
+            PROVISIONING_PROFILE_SPECIFIER="$IOS_ADHOC_PROVISIONING_PROFILE_NAME" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            OTHER_CODE_SIGN_FLAGS="--keychain $PANDATRACK_SIGNING_KEYCHAIN"
+
+      - name: Export ad-hoc IPA
+        run: |
+          set -euo pipefail
+
+          EXPORT_OPTIONS_PLIST="$RUNNER_TEMP/ExportOptions.plist"
+          EXPORT_PATH="$RUNNER_TEMP/pandatrack-adhoc-ipa"
+
+          cat > "$EXPORT_OPTIONS_PLIST" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>ad-hoc</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>teamID</key>
+            <string>${IOS_DEVELOPMENT_TEAM_ID}</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>${PANDATRACK_BUNDLE_IDENTIFIER}</key>
+              <string>${IOS_ADHOC_PROVISIONING_PROFILE_UUID}</string>
+            </dict>
+            <key>compileBitcode</key>
+            <false/>
+            <key>stripSwiftSymbols</key>
+            <true/>
+            <key>thinning</key>
+            <string>&lt;none&gt;</string>
+          </dict>
+          </plist>
+          EOF
+
+          mkdir -p "$EXPORT_PATH"
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Pandatrack.xcarchive" \
+            -exportOptionsPlist "$EXPORT_OPTIONS_PLIST" \
+            -exportPath "$EXPORT_PATH"
+
+      - name: Upload ad-hoc IPA
+        uses: actions/upload-artifact@v7
+        with:
+          name: pandatrack-ad-hoc-ipa
+          path: ${{ runner.temp }}/pandatrack-adhoc-ipa/*.ipa
+          if-no-files-found: error
+
+      - name: Clean up signing assets
+        if: always()
+        run: |
+          set +e
+          if [ -n "${PANDATRACK_SIGNING_KEYCHAIN:-}" ]; then
+            security delete-keychain "$PANDATRACK_SIGNING_KEYCHAIN"
+          fi
+          rm -f "${PANDATRACK_CERTIFICATE_PATH:-}"
+          rm -f "${IOS_ADHOC_PROVISIONING_PROFILE_PATH:-}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,16 +125,20 @@ jobs:
           github.event_name == 'push' ||
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         run: |
-          set -o pipefail
+          set -euo pipefail
+
+          python3 .github/scripts/configure-ios-signing.py \
+            Chronos.xcodeproj/project.pbxproj \
+            --bundle-identifier "$PANDATRACK_BUNDLE_IDENTIFIER" \
+            --team-id "$IOS_DEVELOPMENT_TEAM_ID" \
+            --profile-name "$IOS_ADHOC_PROVISIONING_PROFILE_NAME" \
+            --signing-identity "$PANDATRACK_CODE_SIGN_IDENTITY"
+
           xcodebuild archive \
             -workspace Chronos.xcworkspace \
             -scheme Pandatrack \
             -destination "generic/platform=iOS" \
             -archivePath "$RUNNER_TEMP/Pandatrack.xcarchive" \
-            CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM="$IOS_DEVELOPMENT_TEAM_ID" \
-            PROVISIONING_PROFILE_SPECIFIER="$IOS_ADHOC_PROVISIONING_PROFILE_NAME" \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
             OTHER_CODE_SIGN_FLAGS="--keychain $PANDATRACK_SIGNING_KEYCHAIN"
 
       - name: Export ad-hoc IPA

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           {
             echo "PANDATRACK_SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
             echo "PANDATRACK_CERTIFICATE_PATH=$CERTIFICATE_PATH"
+            echo "PANDATRACK_SIGNING_IDENTITIES_PATH=$SIGNING_IDENTITIES_PATH"
           } >> "$GITHUB_ENV"
 
       - name: Install ad-hoc provisioning profile
@@ -103,6 +104,10 @@ jobs:
           TEAM_ID="$(/usr/libexec/PlistBuddy -c 'Print TeamIdentifier:0' "$PROFILE_PLIST")"
           APPLICATION_IDENTIFIER="$(/usr/libexec/PlistBuddy -c 'Print Entitlements:application-identifier' "$PROFILE_PLIST")"
           BUNDLE_IDENTIFIER="${APPLICATION_IDENTIFIER#${TEAM_ID}.}"
+
+          python3 .github/scripts/select-ios-signing-identity.py \
+            "$PROFILE_PLIST" \
+            "$PANDATRACK_SIGNING_IDENTITIES_PATH"
 
           mkdir -p "$PROFILE_INSTALL_DIR"
           cp "$PROFILE_PATH" "$PROFILE_INSTALL_DIR/$PROFILE_UUID.mobileprovision"
@@ -195,6 +200,7 @@ jobs:
             security delete-keychain "$PANDATRACK_SIGNING_KEYCHAIN"
           fi
           rm -f "${PANDATRACK_CERTIFICATE_PATH:-}"
+          rm -f "${PANDATRACK_SIGNING_IDENTITIES_PATH:-}"
           rm -f "${IOS_ADHOC_PROVISIONING_PROFILE_PATH:-}"
 
   unit-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,15 +136,23 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security import "$CERTIFICATE_PATH" \
             -f pkcs12 \
+            -t cert \
             -k "$KEYCHAIN_PATH" \
             -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" \
+            -A \
             -T /usr/bin/codesign \
             -T /usr/bin/security \
             -T /usr/bin/xcodebuild
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           security default-keychain -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          SIGNING_IDENTITIES_PATH="$RUNNER_TEMP/pandatrack-signing-identities.txt"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | tee "$SIGNING_IDENTITIES_PATH"
+          if ! grep -Eq '^[[:space:]]+[0-9]+\) [[:xdigit:]]+ ".+"$' "$SIGNING_IDENTITIES_PATH"; then
+            echo "::error::The imported certificate did not include a valid code-signing identity."
+            echo "::error::Update IOS_DISTRIBUTION_CERTIFICATE_BASE64 with a .p12 export that includes the private key."
+            exit 1
+          fi
 
           {
             echo "PANDATRACK_SIGNING_KEYCHAIN=$KEYCHAIN_PATH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,164 @@ jobs:
             -destination "platform=iOS Simulator,id=${PANDATRACK_SIMULATOR_UDID}" \
             CODE_SIGNING_ALLOWED=NO
 
+      - name: Import signing certificate
+        if: >
+          github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/ios_distribution_certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/pandatrack-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+
+          printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH" \
+            -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" \
+            -A \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security \
+            -T /usr/bin/xcodebuild
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+
+          SIGNING_IDENTITIES_PATH="$RUNNER_TEMP/pandatrack-signing-identities.txt"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | tee "$SIGNING_IDENTITIES_PATH"
+          if ! grep -Eq '^[[:space:]]+[0-9]+\) [[:xdigit:]]+ ".+"$' "$SIGNING_IDENTITIES_PATH"; then
+            echo "::error::The imported certificate did not include a valid code-signing identity."
+            echo "::error::Update IOS_DISTRIBUTION_CERTIFICATE_BASE64 with a .p12 export that includes the private key."
+            exit 1
+          fi
+
+          {
+            echo "PANDATRACK_SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
+            echo "PANDATRACK_CERTIFICATE_PATH=$CERTIFICATE_PATH"
+          } >> "$GITHUB_ENV"
+
+      - name: Install ad-hoc provisioning profile
+        if: >
+          github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        env:
+          IOS_ADHOC_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_ADHOC_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+
+          PROFILE_PATH="$RUNNER_TEMP/pandatrack-adhoc.mobileprovision"
+          PROFILE_PLIST="$RUNNER_TEMP/pandatrack-adhoc.plist"
+          PROFILE_INSTALL_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+
+          printf '%s' "$IOS_ADHOC_PROVISIONING_PROFILE_BASE64" | base64 -D > "$PROFILE_PATH"
+          security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
+
+          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PROFILE_PLIST")"
+          PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")"
+          TEAM_ID="$(/usr/libexec/PlistBuddy -c 'Print TeamIdentifier:0' "$PROFILE_PLIST")"
+          APPLICATION_IDENTIFIER="$(/usr/libexec/PlistBuddy -c 'Print Entitlements:application-identifier' "$PROFILE_PLIST")"
+          BUNDLE_IDENTIFIER="${APPLICATION_IDENTIFIER#${TEAM_ID}.}"
+
+          mkdir -p "$PROFILE_INSTALL_DIR"
+          cp "$PROFILE_PATH" "$PROFILE_INSTALL_DIR/$PROFILE_UUID.mobileprovision"
+
+          {
+            echo "IOS_ADHOC_PROVISIONING_PROFILE_UUID=$PROFILE_UUID"
+            echo "IOS_ADHOC_PROVISIONING_PROFILE_NAME=$PROFILE_NAME"
+            echo "IOS_ADHOC_PROVISIONING_PROFILE_PATH=$PROFILE_INSTALL_DIR/$PROFILE_UUID.mobileprovision"
+            echo "IOS_DEVELOPMENT_TEAM_ID=$TEAM_ID"
+            echo "PANDATRACK_BUNDLE_IDENTIFIER=$BUNDLE_IDENTIFIER"
+          } >> "$GITHUB_ENV"
+
+      - name: Archive app
+        if: >
+          github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
+          set -o pipefail
+          xcodebuild archive \
+            -workspace Chronos.xcworkspace \
+            -scheme Pandatrack \
+            -destination "generic/platform=iOS" \
+            -archivePath "$RUNNER_TEMP/Pandatrack.xcarchive" \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="$IOS_DEVELOPMENT_TEAM_ID" \
+            PROVISIONING_PROFILE_SPECIFIER="$IOS_ADHOC_PROVISIONING_PROFILE_NAME" \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
+            OTHER_CODE_SIGN_FLAGS="--keychain $PANDATRACK_SIGNING_KEYCHAIN"
+
+      - name: Export ad-hoc IPA
+        if: >
+          github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
+          set -euo pipefail
+
+          EXPORT_OPTIONS_PLIST="$RUNNER_TEMP/ExportOptions.plist"
+          EXPORT_PATH="$RUNNER_TEMP/pandatrack-adhoc-ipa"
+
+          cat > "$EXPORT_OPTIONS_PLIST" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>ad-hoc</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>teamID</key>
+            <string>${IOS_DEVELOPMENT_TEAM_ID}</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>${PANDATRACK_BUNDLE_IDENTIFIER}</key>
+              <string>${IOS_ADHOC_PROVISIONING_PROFILE_UUID}</string>
+            </dict>
+            <key>compileBitcode</key>
+            <false/>
+            <key>stripSwiftSymbols</key>
+            <true/>
+            <key>thinning</key>
+            <string>&lt;none&gt;</string>
+          </dict>
+          </plist>
+          EOF
+
+          mkdir -p "$EXPORT_PATH"
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/Pandatrack.xcarchive" \
+            -exportOptionsPlist "$EXPORT_OPTIONS_PLIST" \
+            -exportPath "$EXPORT_PATH"
+
+      - name: Upload ad-hoc IPA
+        if: >
+          github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/upload-artifact@v7
+        with:
+          name: pandatrack-ad-hoc-ipa
+          path: ${{ runner.temp }}/pandatrack-adhoc-ipa/*.ipa
+          if-no-files-found: error
+
+      - name: Clean up signing assets
+        if: >
+          always() &&
+          (github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
+        run: |
+          set +e
+          if [ -n "${PANDATRACK_SIGNING_KEYCHAIN:-}" ]; then
+            security delete-keychain "$PANDATRACK_SIGNING_KEYCHAIN"
+          fi
+          rm -f "${PANDATRACK_CERTIFICATE_PATH:-}"
+          rm -f "${IOS_ADHOC_PROVISIONING_PROFILE_PATH:-}"
+
   unit-tests:
     name: Unit Tests
     runs-on: macos-15
@@ -96,164 +254,3 @@ jobs:
             -destination "platform=iOS Simulator,id=${PANDATRACK_SIMULATOR_UDID}" \
             -only-testing:ChronosUITests \
             CODE_SIGNING_ALLOWED=NO
-
-  export-ad-hoc-ipa:
-    name: Export Ad-Hoc IPA
-    runs-on: macos-15
-    needs:
-      - build
-      - unit-tests
-      - instrumented-tests
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
-
-      - name: Install CocoaPods dependencies
-        run: pod install --repo-update
-
-      - name: Import signing certificate
-        env:
-          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
-          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          CERTIFICATE_PATH="$RUNNER_TEMP/ios_distribution_certificate.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/pandatrack-signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(uuidgen)"
-
-          printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERTIFICATE_PATH" \
-            -f pkcs12 \
-            -k "$KEYCHAIN_PATH" \
-            -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" \
-            -A \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security \
-            -T /usr/bin/xcodebuild
-          security list-keychains -d user -s "$KEYCHAIN_PATH"
-          security default-keychain -s "$KEYCHAIN_PATH"
-
-          SIGNING_IDENTITIES_PATH="$RUNNER_TEMP/pandatrack-signing-identities.txt"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | tee "$SIGNING_IDENTITIES_PATH"
-          if ! grep -Eq '^[[:space:]]+[0-9]+\) [[:xdigit:]]+ ".+"$' "$SIGNING_IDENTITIES_PATH"; then
-            echo "::error::The imported certificate did not include a valid code-signing identity."
-            echo "::error::Update IOS_DISTRIBUTION_CERTIFICATE_BASE64 with a .p12 export that includes the private key."
-            exit 1
-          fi
-
-          {
-            echo "PANDATRACK_SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
-            echo "PANDATRACK_CERTIFICATE_PATH=$CERTIFICATE_PATH"
-          } >> "$GITHUB_ENV"
-
-      - name: Install ad-hoc provisioning profile
-        env:
-          IOS_ADHOC_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_ADHOC_PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          set -euo pipefail
-
-          PROFILE_PATH="$RUNNER_TEMP/pandatrack-adhoc.mobileprovision"
-          PROFILE_PLIST="$RUNNER_TEMP/pandatrack-adhoc.plist"
-          PROFILE_INSTALL_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
-
-          printf '%s' "$IOS_ADHOC_PROVISIONING_PROFILE_BASE64" | base64 -D > "$PROFILE_PATH"
-          security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
-
-          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PROFILE_PLIST")"
-          PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")"
-          TEAM_ID="$(/usr/libexec/PlistBuddy -c 'Print TeamIdentifier:0' "$PROFILE_PLIST")"
-          APPLICATION_IDENTIFIER="$(/usr/libexec/PlistBuddy -c 'Print Entitlements:application-identifier' "$PROFILE_PLIST")"
-          BUNDLE_IDENTIFIER="${APPLICATION_IDENTIFIER#${TEAM_ID}.}"
-
-          mkdir -p "$PROFILE_INSTALL_DIR"
-          cp "$PROFILE_PATH" "$PROFILE_INSTALL_DIR/$PROFILE_UUID.mobileprovision"
-
-          {
-            echo "IOS_ADHOC_PROVISIONING_PROFILE_UUID=$PROFILE_UUID"
-            echo "IOS_ADHOC_PROVISIONING_PROFILE_NAME=$PROFILE_NAME"
-            echo "IOS_ADHOC_PROVISIONING_PROFILE_PATH=$PROFILE_INSTALL_DIR/$PROFILE_UUID.mobileprovision"
-            echo "IOS_DEVELOPMENT_TEAM_ID=$TEAM_ID"
-            echo "PANDATRACK_BUNDLE_IDENTIFIER=$BUNDLE_IDENTIFIER"
-          } >> "$GITHUB_ENV"
-
-      - name: Archive app
-        run: |
-          set -o pipefail
-          xcodebuild archive \
-            -workspace Chronos.xcworkspace \
-            -scheme Pandatrack \
-            -destination "generic/platform=iOS" \
-            -archivePath "$RUNNER_TEMP/Pandatrack.xcarchive" \
-            CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM="$IOS_DEVELOPMENT_TEAM_ID" \
-            PROVISIONING_PROFILE_SPECIFIER="$IOS_ADHOC_PROVISIONING_PROFILE_NAME" \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-            OTHER_CODE_SIGN_FLAGS="--keychain $PANDATRACK_SIGNING_KEYCHAIN"
-
-      - name: Export ad-hoc IPA
-        run: |
-          set -euo pipefail
-
-          EXPORT_OPTIONS_PLIST="$RUNNER_TEMP/ExportOptions.plist"
-          EXPORT_PATH="$RUNNER_TEMP/pandatrack-adhoc-ipa"
-
-          cat > "$EXPORT_OPTIONS_PLIST" <<EOF
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key>
-            <string>ad-hoc</string>
-            <key>signingStyle</key>
-            <string>manual</string>
-            <key>teamID</key>
-            <string>${IOS_DEVELOPMENT_TEAM_ID}</string>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>${PANDATRACK_BUNDLE_IDENTIFIER}</key>
-              <string>${IOS_ADHOC_PROVISIONING_PROFILE_UUID}</string>
-            </dict>
-            <key>compileBitcode</key>
-            <false/>
-            <key>stripSwiftSymbols</key>
-            <true/>
-            <key>thinning</key>
-            <string>&lt;none&gt;</string>
-          </dict>
-          </plist>
-          EOF
-
-          mkdir -p "$EXPORT_PATH"
-          xcodebuild -exportArchive \
-            -archivePath "$RUNNER_TEMP/Pandatrack.xcarchive" \
-            -exportOptionsPlist "$EXPORT_OPTIONS_PLIST" \
-            -exportPath "$EXPORT_PATH"
-
-      - name: Upload ad-hoc IPA
-        uses: actions/upload-artifact@v7
-        with:
-          name: pandatrack-ad-hoc-ipa
-          path: ${{ runner.temp }}/pandatrack-adhoc-ipa/*.ipa
-          if-no-files-found: error
-
-      - name: Clean up signing assets
-        if: always()
-        run: |
-          set +e
-          if [ -n "${PANDATRACK_SIGNING_KEYCHAIN:-}" ]; then
-            security delete-keychain "$PANDATRACK_SIGNING_KEYCHAIN"
-          fi
-          rm -f "${PANDATRACK_CERTIFICATE_PATH:-}"
-          rm -f "${IOS_ADHOC_PROVISIONING_PROFILE_PATH:-}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security import "$CERTIFICATE_PATH" \
             -f pkcs12 \
-            -t cert \
             -k "$KEYCHAIN_PATH" \
             -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" \
             -A \


### PR DESCRIPTION
closes valomedia/Pandatrack#28

Added a trusted export-ad-hoc-ipa GitHub Actions job that waits for the existing build, unit test, and instrumented test jobs; skips fork pull requests; imports the Apple distribution certificate into a temporary CI keychain; installs the ad-hoc provisioning profile; archives the Pandatrack scheme from Chronos.xcworkspace for a generic iOS device with manual signing; exports an ad-hoc IPA; uploads it as the pandatrack-ad-hoc-ipa artifact; and cleans up temporary signing assets. Verification passed: CI workflow structural checks, bash syntax checks for all workflow run scripts, git diff --check, and confirmation that the shared Pandatrack Xcode scheme exists. Local Xcode archive/export verification was not possible because xcodebuild is unavailable in this Linux worker. Committed changes as f6c976e (ci: export ad-hoc ipa artifact).