### PR TITLE
test: stabilize entry creation UI test

### DIFF
--- a/Chronos/Views/EntriesTab.swift
+++ b/Chronos/Views/EntriesTab.swift
@@ -42,7 +42,9 @@ struct EntriesTab: View {
             }
                     .searchable(text: $search)
                     .navigationTitle("Time Entries")
-                    .floatingActionButton { isPresentingEditView = true }
+                    .floatingActionButton(accessibilityIdentifier: "addEntryButton") {
+                        isPresentingEditView = true
+                    }
                     .modal("New Entry", isPresented: $isPresentingEditView, onOpen: { newEntry = CompletedEntry(moc)}) {
                         if let newEntry { EntryDetailEditView(entry: newEntry) }
                     }

--- a/Chronos/Views/FloatingActionButton.swift
+++ b/Chronos/Views/FloatingActionButton.swift
@@ -16,8 +16,9 @@ struct FloatingActionButton: View {
 
     // MARK: - Life cycle methods
 
-    init(image: Image? = nil, action: (()->())? = nil) {
+    init(image: Image? = nil, accessibilityIdentifier: String? = nil, action: (()->())? = nil) {
         self.image = image ?? Image(systemName: "plus")
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.action = action ?? {}
     }
 
@@ -35,11 +36,14 @@ struct FloatingActionButton: View {
                 .if(colorScheme == .light) { $0.colorInvert() }
                 .background(Circle().fill(Color.accentColor))
                 .accessibilityLabel("Add")
+                .ifNotNil(accessibilityIdentifier) { $0.accessibilityIdentifier($1) }
                 .padding()
     }
 
     @Environment(\.colorScheme)
     private var colorScheme: ColorScheme
+
+    private let accessibilityIdentifier: String?
 
     // MARK: - Methods
 

--- a/Chronos/Views/View+floatingActionButton.swift
+++ b/Chronos/Views/View+floatingActionButton.swift
@@ -14,14 +14,20 @@ import SwiftUI
 
 extension View {
 
-    func floatingActionButton(image: Image? = nil, action: (()->())? = nil) -> some View {
+    func floatingActionButton(
+            image: Image? = nil,
+            accessibilityIdentifier: String? = nil,
+            action: (()->())? = nil) -> some View {
         ZStack {
             self
             VStack {
                 Spacer()
                 HStack {
                     Spacer()
-                    FloatingActionButton(image: image, action: action)
+                    FloatingActionButton(
+                            image: image,
+                            accessibilityIdentifier: accessibilityIdentifier,
+                            action: action)
                 }
             }
         }

--- a/ChronosUITests/ChronosUITests.swift
+++ b/ChronosUITests/ChronosUITests.swift
@@ -53,7 +53,9 @@ class ChronosUITests: XCTestCase {
         XCTAssertTrue(app.navigationBars["Time Entries"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Hi, I‘m Pandy!"].exists)
 
-        app.buttons["Add"].tap()
+        let addEntryButton = app.buttons["addEntryButton"]
+        XCTAssertTrue(addEntryButton.waitForExistence(timeout: 5))
+        addEntryButton.tap()
 
         let nameField = app.textFields["Name"]
         XCTAssertTrue(nameField.waitForExistence(timeout: 5))


### PR DESCRIPTION
closes valomedia/Pandatrack#33

Investigated the failing main CI run 29203870588 and confirmed `ChronosUITests.testCreatesTimeEntry()` was tapping the generic `Add` button, then timing out waiting for the `Name` text field. The branch now adds optional accessibility identifier support to the shared floating action button helper, assigns the Entries tab add button the stable `addEntryButton` identifier, and updates the UI test to wait for and tap that specific button instead of the ambiguous generic label. Committed the changes as `2031357 test: stabilize entry creation UI test`.

Verification: reviewed the failed GitHub Actions log with `gh run view --log-failed`; confirmed the relevant SwiftUI helper/test patterns by source inspection; ran `git diff --check HEAD~1..HEAD` successfully; confirmed the working tree is clean. Xcode simulator build/test verification was unavailable in this Linux container because `xcodebuild` is not installed.